### PR TITLE
explicitly paint to see effect of shader change

### DIFF
--- a/source/examples/qtexample/main.cpp
+++ b/source/examples/qtexample/main.cpp
@@ -122,16 +122,20 @@ public:
     {
         makeCurrent();
 
+        bool reloadedShaders = false;
         switch (event->key())
         {
         case Qt::Key_F5:
             m_vertexShaderSource->reload();
             m_fragmentShaderSource->reload();
+            reloadedShaders = true;
             break;
         default:
             break;
         }
         doneCurrent();
+        if(reloadedShaders)
+            paint();
     }
 
 


### PR DESCRIPTION
At least for me on windows 10 with either OpenGL 3.x or 4.x, the window did not get updated until dragging off-screen or minimizing. 
Explicitly calling paint() remedies this; the window changes shaders instantaneously on F5.